### PR TITLE
Add MX10 PRINTER_CAT

### DIFF
--- a/src/Thermal_Printer.cpp
+++ b/src/Thermal_Printer.cpp
@@ -82,6 +82,7 @@ const PRINTERID szPrinterIDs[] = {
 	{(char *)"PeriPage_", PRINTER_PERIPAGE},
 	{(char *)"T02", PRINTER_FOMEMO},
 	{(char *)"MX06", PRINTER_CAT},
+	{(char *)"MX10", PRINTER_CAT},
 	{NULL, 0}		// terminator
 };
 const int iPrinterWidth[] = {384, 576, 384, 576, 384, 384};


### PR DESCRIPTION
I've encounter this other device name working with my cat printer. Adding the name, and it connects and prints.
Image is a little fade out, but I guess that it's more on the prepossessing the image side of things.

love the library💫